### PR TITLE
feature: make _Any, NodeObject private to federation

### DIFF
--- a/core/src/main/scala/sangria/federation/NodeObject.scala
+++ b/core/src/main/scala/sangria/federation/NodeObject.scala
@@ -1,6 +1,6 @@
 package sangria.federation
 
-trait NodeObject[Node] {
+private[federation] trait NodeObject[Node] {
 
   def __typename: Option[String]
   def decode[T](implicit ev: Decoder[Node, T]): Either[Exception, T]

--- a/core/src/main/scala/sangria/federation/_Any.scala
+++ b/core/src/main/scala/sangria/federation/_Any.scala
@@ -1,8 +1,8 @@
 package sangria.federation
 
-case class _Any[Node](__typename: String, fields: NodeObject[Node])
+private[federation] case class _Any[Node](__typename: String, fields: NodeObject[Node])
 
-object _Any {
+private[federation] object _Any {
 
   import sangria.schema.ScalarType
   import sangria.validation.ValueCoercionViolation


### PR DESCRIPTION
please review 🙏 

### Motivation

The _Any type is a scalar in the form of map values, which are encoded as NodeObject values, and these can lead to potential vulnerabilities (as discussed [here](http://www.petecorey.com/blog/2017/06/12/graphql-nosql-injection-through-json-types/)). In fact, both types are meant to be used only internally by the library (with the _entities field in federation).According to these facts, making _Any and NodeObject private to the library will keep the sangria GraphQL type safety.