### PR TITLE
feat(sdl): make sure sdl resolver does only filter GraphQL built-in types

### DIFF
--- a/core/src/main/scala/sangria/federation/Federation.scala
+++ b/core/src/main/scala/sangria/federation/Federation.scala
@@ -2,6 +2,7 @@ package sangria.federation
 
 import sangria.ast.Document
 import sangria.marshalling.InputUnmarshaller
+import sangria.renderer.SchemaFilter
 import sangria.schema._
 
 object Federation {
@@ -23,7 +24,7 @@ object Federation {
       case obj: ObjectType[Ctx, _] @unchecked if obj.astDirectives.exists(_.name == "key") => obj
     }.toList
 
-    val sdl = Some(schema.renderPretty)
+    val sdl = Some(schema.renderPretty(SchemaFilter.withoutGraphQLBuiltIn))
 
     (entities match {
       case Nil =>


### PR DESCRIPTION
please review 🙏 

In this PR, I am making sure to only filter GraphQL built-in types and no Sangria types because, if done otherwise, the federation gateway will complain about not knowing the Sangria types (e.g. Long).