### PR TITLE
Fetch entities in bulk instead of one by one

### DIFF
--- a/core/src/main/scala/sangria/federation/v1/EntityResolver.scala
+++ b/core/src/main/scala/sangria/federation/v1/EntityResolver.scala
@@ -5,28 +5,33 @@ import sangria.schema._
 trait EntityResolver[Ctx, Node] {
 
   type Arg
+  type Val
 
   val decoder: Decoder[Node, Arg]
 
   def typename: String
-  def resolve(arg: Arg, ctx: Context[Ctx, _]): LeafAction[Ctx, Option[_]]
+  def resolve(arg: Seq[Arg], ctx: Context[Ctx, Val]): LeafAction[Ctx, Iterable[Val]]
+  def arg(v: Val): Arg
 }
 
 object EntityResolver {
-
-  def apply[Ctx, Node, Val, A](
+  def apply[Ctx, Node, Value, Id](
       __typeName: String,
-      resolver: (A, Context[Ctx, Val]) => LeafAction[Ctx, Option[Val]]
-  )(implicit ev: Decoder[Node, A]): EntityResolver[Ctx, Node] {
-    type Arg = A
-  } = new EntityResolver[Ctx, Node] {
+      resolver: (Seq[Id], Context[Ctx, Value]) => LeafAction[Ctx, Iterable[Value]],
+      id: Value => Id
+  )(implicit ev: Decoder[Node, Id]): EntityResolver[Ctx, Node] { type Arg = Id; type Val = Value } =
+    new EntityResolver[Ctx, Node] {
 
-    type Arg = A
+      override type Arg = Id
+      override type Val = Value
 
-    val decoder: Decoder[Node, A] = ev
+      override val decoder: Decoder[Node, Id] = ev
 
-    def typename: String = __typeName
-    def resolve(arg: Arg, ctx: Context[Ctx, _]): LeafAction[Ctx, Option[Val]] =
-      resolver(arg, ctx.asInstanceOf[Context[Ctx, Val]])
-  }
+      override def typename: String = __typeName
+
+      override def resolve(arg: Seq[Arg], ctx: Context[Ctx, Val]): LeafAction[Ctx, Iterable[Val]] =
+        resolver(arg, ctx)
+
+      override def arg(v: Value): Id = id(v)
+    }
 }

--- a/core/src/main/scala/sangria/federation/v1/Federation.scala
+++ b/core/src/main/scala/sangria/federation/v1/Federation.scala
@@ -1,9 +1,12 @@
 package sangria.federation.v1
 
 import sangria.ast
-import sangria.marshalling.InputUnmarshaller
+import sangria.marshalling.{FromInput, InputUnmarshaller}
 import sangria.renderer.SchemaFilter
 import sangria.schema._
+import sangria.util.tag.@@
+
+import scala.collection.mutable
 
 object Federation {
   import Query._
@@ -44,14 +47,34 @@ object Federation {
                 "_service" -> (_ => _Service(sdl)),
                 "_entities" -> (ctx =>
                   ctx.withArgs(representationsArg) { anys =>
-                    Action.sequence(anys.map { any =>
-                      val resolver = resolversMap(any.__typename)
+                    val anysWithArgs: Seq[ResolvedAny[Ctx, Node]] =
+                      anys.map(any => ResolvedAny(any, resolversMap(any.__typename)))
 
-                      any.fields.decode[resolver.Arg](resolver.decoder) match {
-                        case Right(value) => resolver.resolve(value, ctx)
-                        case Left(_) => LeafAction(None)
+                    val requestsByTypename = anysWithArgs.groupBy(_.any.__typename)
+                    val resolvedBuilder = mutable.Map[ResolvedKey, LeafAction[Ctx, Any]]()
+                    requestsByTypename.foreach { case (typename, elements) =>
+                      // the resolver is the same for all elements as it's per type
+                      val resolver = elements.head.resolver
+                      val bulkArgs = elements.map(_.arg)
+
+                      if (bulkArgs.nonEmpty) {
+                        resolver.resolve(
+                          bulkArgs.asInstanceOf[Seq[resolver.Arg]],
+                          ctx.asInstanceOf[Context[Ctx, resolver.Val]]) match {
+                          case Value(results) =>
+                            results.foreach { result =>
+                              val arg = resolver.arg(result)
+                              resolvedBuilder(ResolvedKey(typename, arg)) = LeafAction(result)
+                            }
+                          case e => throw new Exception("expecting Value and got " + e)
+                        }
                       }
-                    })
+                    }
+
+                    val resolved = resolvedBuilder.withDefault(_ => LeafAction(None))
+                    val results =
+                      anysWithArgs.map(a => resolved(ResolvedKey(a.any.__typename, a.arg)))
+                    Action.sequence(results)
                   })
               )
             ),
@@ -59,6 +82,16 @@ object Federation {
           )
         )
     }).copy(directives = Directives.definitions ::: schema.directives)
+  }
+
+  private case class ResolvedKey(typename: String, arg: Any)
+  private case class ResolvedAny[Ctx, Node](
+      any: @@[_Any[Node], FromInput.CoercedScalaResult],
+      resolver: EntityResolver[Ctx, Node]) {
+    val arg: resolver.Arg = any.fields.decode[resolver.Arg](resolver.decoder) match {
+      case Right(arg) => arg
+      case Left(e) => throw e
+    }
   }
 
   def upgrade[Node](default: InputUnmarshaller[Node]): InputUnmarshaller[Node] =

--- a/core/src/main/scala/sangria/federation/v2/EntityResolver.scala
+++ b/core/src/main/scala/sangria/federation/v2/EntityResolver.scala
@@ -5,28 +5,33 @@ import sangria.schema._
 trait EntityResolver[Ctx, Node] {
 
   type Arg
+  type Val
 
   val decoder: Decoder[Node, Arg]
 
   def typename: String
-  def resolve(arg: Arg, ctx: Context[Ctx, _]): LeafAction[Ctx, Option[_]]
+  def resolve(arg: Seq[Arg], ctx: Context[Ctx, Val]): LeafAction[Ctx, Iterable[Val]]
+  def arg(v: Val): Arg
 }
 
 object EntityResolver {
-
-  def apply[Ctx, Node, Val, A](
+  def apply[Ctx, Node, Value, Id](
       __typeName: String,
-      resolver: (A, Context[Ctx, Val]) => LeafAction[Ctx, Option[Val]]
-  )(implicit ev: Decoder[Node, A]): EntityResolver[Ctx, Node] {
-    type Arg = A
-  } = new EntityResolver[Ctx, Node] {
+      resolver: (Seq[Id], Context[Ctx, Value]) => LeafAction[Ctx, Iterable[Value]],
+      id: Value => Id
+  )(implicit ev: Decoder[Node, Id]): EntityResolver[Ctx, Node] { type Arg = Id; type Val = Value } =
+    new EntityResolver[Ctx, Node] {
 
-    type Arg = A
+      override type Arg = Id
+      override type Val = Value
 
-    val decoder: Decoder[Node, A] = ev
+      override val decoder: Decoder[Node, Id] = ev
 
-    def typename: String = __typeName
-    def resolve(arg: Arg, ctx: Context[Ctx, _]): LeafAction[Ctx, Option[Val]] =
-      resolver(arg, ctx.asInstanceOf[Context[Ctx, Val]])
-  }
+      override def typename: String = __typeName
+
+      override def resolve(arg: Seq[Arg], ctx: Context[Ctx, Val]): LeafAction[Ctx, Iterable[Val]] =
+        resolver(arg, ctx)
+
+      override def arg(v: Value): Id = id(v)
+    }
 }

--- a/core/src/test/scala/sangria/federation/v2/FederationSpec.scala
+++ b/core/src/test/scala/sangria/federation/v2/FederationSpec.scala
@@ -288,27 +288,17 @@ class FederationSpec extends AsyncFreeSpec {
       val Success(query) = QueryParser.parse("""
          query FetchState($representations: [_Any!]!) {
            _entities(representations: $representations) {
-             ... on State {
-               id
-               value
-             }
-             ... on Review {
-               id
-               value
-             }
+             ... on State { id value }
+             ... on Review { id value }
+             ... on Review2 { id value2 }
            }
          }
          """)
 
-      val args: Json = parse(""" { "representations": [{ "__typename": "State", "id": 1 }] } """)
-        .getOrElse(Json.Null)
-
       import sangria.marshalling.queryAst.queryAstResultMarshaller
 
       "should succeed on federated unmarshaller" in {
-
         implicit val um = Federation.upgrade(sangria.marshalling.circe.CirceInputUnmarshaller)
-
         val args: Json = parse(""" { "representations": [{ "__typename": "State", "id": 1 }] } """)
           .getOrElse(Json.Null)
 
@@ -325,9 +315,7 @@ class FederationSpec extends AsyncFreeSpec {
       }
 
       "should fail on regular unmarshaller" in {
-
         implicit val um = sangria.marshalling.circe.CirceInputUnmarshaller
-
         val args: Json = parse(""" { "representations": [{ "__typename": "State", "id": 1 }] } """)
           .getOrElse(Json.Null)
 
@@ -337,10 +325,42 @@ class FederationSpec extends AsyncFreeSpec {
         }
       }
 
-      "should fetch several entities" in {
-
+      "should fetch several entities of same type in one call" in {
         implicit val um = Federation.upgrade(sangria.marshalling.circe.CirceInputUnmarshaller)
+        val args: Json = parse("""
+          {
+            "representations": [
+              { "__typename": "State", "id": 1 },
+              { "__typename": "State", "id": 2 },
+              { "__typename": "State", "id": 20 },
+              { "__typename": "State", "id": 5 }
+            ]
+          }
+        """).getOrElse(Json.Null)
 
+        Executor
+          .execute(FederationSpec.Schema.schema, query, variables = args)
+          .map(QueryRenderer.renderPretty(_) should be("""{
+              |  data: {
+              |    _entities: [{
+              |      id: 1
+              |      value: "mock state 1"
+              |    }, {
+              |      id: 2
+              |      value: "mock state 2"
+              |    }, {
+              |      id: 20
+              |      value: "mock state 20"
+              |    }, {
+              |      id: 5
+              |      value: "mock state 5"
+              |    }]
+              |  }
+              |}""".stripMargin))
+      }
+
+      "should fetch several entities of different types in one call" in {
+        implicit val um = Federation.upgrade(sangria.marshalling.circe.CirceInputUnmarshaller)
         val args: Json = parse("""
           {
             "representations": [
@@ -380,6 +400,63 @@ class FederationSpec extends AsyncFreeSpec {
               |  }
               |}""".stripMargin))
       }
+
+      "handles non found entities" in {
+        implicit val um = Federation.upgrade(sangria.marshalling.circe.CirceInputUnmarshaller)
+        val args: Json = parse("""
+          {
+            "representations": [
+              { "__typename": "State", "id": 1 },
+              { "__typename": "State", "id": 42 },
+              { "__typename": "State", "id": 20 }
+            ]
+          }
+        """).getOrElse(Json.Null)
+
+        Executor
+          .execute(FederationSpec.Schema.schema, query, variables = args)
+          .map(QueryRenderer.renderPretty(_) should be("""{
+              |  data: {
+              |    _entities: [{
+              |      id: 1
+              |      value: "mock state 1"
+              |    }, null, {
+              |      id: 20
+              |      value: "mock state 20"
+              |    }]
+              |  }
+              |}""".stripMargin))
+      }
+
+      "handles entities using same arg" in {
+        implicit val um = Federation.upgrade(sangria.marshalling.circe.CirceInputUnmarshaller)
+        val args: Json = parse("""
+          {
+            "representations": [
+              { "__typename": "Review", "id": 1 },
+              { "__typename": "Review2", "id": 1 },
+              { "__typename": "Review2", "id": 2 }
+            ]
+          }
+        """).getOrElse(Json.Null)
+
+        Executor
+          .execute(FederationSpec.Schema.schema, query, variables = args)
+          .map(QueryRenderer.renderPretty(_) should be("""{
+              |  data: {
+              |    _entities: [{
+              |      id: 1
+              |      value: "mock review 1"
+              |    }, {
+              |      id: 1
+              |      value2: "mock review2 1"
+              |    }, {
+              |      id: 2
+              |      value2: "mock review2 2"
+              |    }]
+              |  }
+              |}""".stripMargin))
+      }
     }
   }
 }
@@ -387,43 +464,60 @@ class FederationSpec extends AsyncFreeSpec {
 object FederationSpec {
   object Schema {
     private case class State(id: Int, value: String)
-    private case class StateArg(id: Int)
-
     private val StateType = ObjectType(
       "State",
       fields[Unit, State](
         Field("id", IntType, resolve = _.value.id),
         Field("value", OptionType(StringType), resolve = _.value.value))).withDirective(Key("id"))
+
+    private case class StateArg(id: Int)
     private implicit val stateArgDecoder: Decoder[Json, StateArg] =
       deriveDecoder[StateArg].decodeJson(_)
     private val stateResolver = EntityResolver[Any, Json, State, StateArg](
-      __typeName = "State",
-      (arg, _) => Some(State(arg.id, s"mock state ${arg.id}")))
+      __typeName = StateType.name,
+      (args, _) => args.filterNot(_.id == 42).map(arg => State(arg.id, s"mock state ${arg.id}")),
+      s => StateArg(s.id))
 
     private case class Review(id: Int, value: String)
-    private case class ReviewArg(id: Int)
     private val ReviewType = ObjectType(
       "Review",
       fields[Unit, Review](
         Field("id", IntType, resolve = _.value.id),
         Field("value", OptionType(StringType), resolve = _.value.value))).withDirective(Key("id"))
+
+    private case class ReviewArg(id: Int)
     private implicit val reviewArgDecoder: Decoder[Json, ReviewArg] =
       deriveDecoder[ReviewArg].decodeJson(_)
     private val reviewResolver = EntityResolver[Any, Json, Review, ReviewArg](
-      __typeName = "Review",
-      (arg, _) => Some(Review(arg.id, s"mock review ${arg.id}")))
+      __typeName = ReviewType.name,
+      (args, _) => args.map(arg => Review(arg.id, s"mock review ${arg.id}")),
+      r => ReviewArg(r.id))
+
+    private case class Review2(id: Int, value2: String)
+
+    private val Review2Type = ObjectType(
+      "Review2",
+      fields[Unit, Review2](
+        Field("id", IntType, resolve = _.value.id),
+        Field("value2", OptionType(StringType), resolve = _.value.value2))).withDirective(Key("id"))
+    // review2 uses the same arg as review
+    private val review2Resolver = EntityResolver[Any, Json, Review2, ReviewArg](
+      __typeName = Review2Type.name,
+      (args, _) => args.map(arg => Review2(arg.id, s"mock review2 ${arg.id}")),
+      r => ReviewArg(r.id))
 
     private val Query = ObjectType(
       "Query",
       fields[Unit, Any](
         Field(name = "states", fieldType = ListType(StateType), resolve = _ => Nil),
-        Field(name = "reviews", fieldType = ListType(ReviewType), resolve = _ => Nil)
+        Field(name = "reviews", fieldType = ListType(ReviewType), resolve = _ => Nil),
+        Field(name = "reviews2", fieldType = ListType(Review2Type), resolve = _ => Nil)
       )
     )
 
     val schema: Schema[Any, Any] = Federation.extend(
       sangria.schema.Schema(Query),
-      stateResolver :: reviewResolver :: Nil
+      stateResolver :: reviewResolver :: review2Resolver :: Nil
     )
   }
 }

--- a/example/state/src/main/scala/state/State.scala
+++ b/example/state/src/main/scala/state/State.scala
@@ -13,11 +13,14 @@ object StateGraphQLSchema {
 
   implicit val decoder: Decoder[Json, StateArg] = deriveDecoder[StateArg].decodeJson(_)
 
-  val stateResolver = EntityResolver[StateService, Json, State, StateArg](
-    __typeName = "State",
-    (arg, ctx) => ctx.ctx.getState(arg.id))
+  val stateResolver: EntityResolver[StateService, Json] =
+    EntityResolver[StateService, Json, State, StateArg](
+      __typeName = "State",
+      (ids, ctx) => ctx.ctx.getStates(ids.map(_.id)),
+      s => StateArg(s.id)
+    )
 
-  val schema =
+  val schema: ObjectType[Unit, State] =
     ObjectType(
       "State",
       fields[Unit, State](

--- a/example/state/src/main/scala/state/StateAPI.scala
+++ b/example/state/src/main/scala/state/StateAPI.scala
@@ -10,5 +10,5 @@ object StateAPI {
       Field(
         name = "states",
         fieldType = ListType(StateGraphQLSchema.schema),
-        resolve = _.ctx.getStates)))
+        resolve = _.ctx.getAllStates)))
 }

--- a/example/state/src/main/scala/state/StateService.scala
+++ b/example/state/src/main/scala/state/StateService.scala
@@ -1,9 +1,12 @@
 package state
 
+import scala.concurrent.Future
+
 trait StateService {
 
-  def getStates: List[State]
-  def getState(id: Int): Option[State]
+  def getAllStates: Future[List[State]]
+  def getStates(ids: Seq[Int]): Future[List[State]]
+  def getState(id: Int): Future[Option[State]]
 }
 
 object StateService {
@@ -16,9 +19,12 @@ object StateService {
       value = "initial"
     ) :: Nil
 
-    def getStates: List[State] = states
+    override def getAllStates: Future[List[State]] = Future.successful(states)
 
-    def getState(id: Int): Option[State] =
-      states.find(_.id == id)
+    def getStates(ids: Seq[Int]): Future[List[State]] =
+      Future.successful(states.filter(s => ids.contains(s.id)))
+
+    def getState(id: Int): Future[Option[State]] =
+      Future.successful(states.find(_.id == id))
   }
 }


### PR DESCRIPTION
This change the API of `EntityResolver`.

Before, the `EntityResolver` was returning on `Option` of the resolved entity:
```
  val stateResolver = EntityResolver[StateService, Json, State, StateArg](
    __typeName = "State",
    (arg, ctx) => ctx.ctx.getState(arg.id))

```

Now, the `EntityResolver` returns on `Iterable` of the resolved entities, based on all `ids`:
```
  val stateResolver: EntityResolver[StateService, Json] =
    EntityResolver[StateService, Json, State, StateArg](
      __typeName = "State",
      (ids, ctx) => ctx.ctx.getStates(ids.map(_.id)),
      s => StateArg(s.id)
    )
```
The `EntityResolver` must also provide a way to extract the `id` of an entity so that we can handle missing entities.