### PR TITLE
Add Apollo federation spec compliance tool in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' test
 
       - name: Compress target directories
-        run: tar cf targets.tar example/state/target example/review/target target example/test/target example/common/target core/target project/target
+        run: tar cf targets.tar example/state/target example/review/target target example/test/target example/common/target example/product/target core/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v3

--- a/.github/workflows/compatibility.yaml
+++ b/.github/workflows/compatibility.yaml
@@ -1,0 +1,43 @@
+name: Federation Specification Compatibility Test
+
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (temurin@8)
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
+
+      - name: Compatibility Test
+        uses: apollographql/federation-subgraph-compatibility@v2
+        with:
+          # [Required] Docker Compose file to start up the subgraph
+          compose: 'example/product/docker-compose.yaml'
+          # [Required] Path to the GraphQL schema file
+          schema: 'example/product/products.graphql'
+          # GraphQL endpoint path, defaults to '' (empty)
+          path: ''
+          # GraphQL endpoint HTTP port, defaults to 4001
+          port: 4001
+          # Turn on debug mode with extra log info
+          debug: false
+          # Github Token / PAT for submitting PR comments
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Boolean flag to indicate whether any failing test should fail the script
+          failOnWarning: false
+          # Boolean flag to indicate whether any failing required functionality test should fail the script
+          failOnRequired: false
+          # Working directory to run the action from. Should be relative from the root of the project.
+          workingDirectory: ''

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val root = (project in file("."))
     description := "Federation for Sangria"
   )
   .settings(noPublishSettings)
-  .aggregate(core, exampleCommon, exampleReview, exampleState, exampleTest)
+  .aggregate(core, exampleCommon, exampleReview, exampleState, exampleProduct, exampleTest)
 
 lazy val core = libraryProject("core")
   .settings(
@@ -73,6 +73,18 @@ lazy val exampleReview = exampleProject("example-review")
 lazy val exampleState = exampleProject("example-state")
   .dependsOn(exampleCommon)
   .settings(libraryDependencies ++= serviceDependencies)
+
+lazy val exampleProduct = exampleProject("example-product")
+  .dependsOn(core)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.sangriaCirce,
+    Dependencies.http4sEmberServer,
+    Dependencies.http4sCirce,
+    Dependencies.http4sDsl,
+    Dependencies.circeOptics,
+    Dependencies.circeGeneric,
+    Dependencies.circeCore
+  ))
 
 lazy val serviceDependencies = Seq(
   Dependencies.logbackClassic,

--- a/example/product/Dockerfile
+++ b/example/product/Dockerfile
@@ -1,0 +1,9 @@
+FROM hseeberger/scala-sbt:17.0.2_1.6.2_3.1.1 AS build
+
+WORKDIR /build
+COPY build.sbt .
+COPY project ./project/
+COPY core ./core
+COPY example/product/src ./example/product/src
+EXPOSE 4001
+CMD sbt example-product/run

--- a/example/product/README.md
+++ b/example/product/README.md
@@ -1,0 +1,17 @@
+# federated subgraph to test apollo federation spec compatibility
+
+Implementation of a federated subgraph aligned to the requirements outlined in [apollo-federation-subgraph-compatibility](https://github.com/apollographql/apollo-federation-subgraph-compatibility).
+
+The subgraph can be used to verify compatibility against [Apollo Federation Subgraph Specification](https://www.apollographql.com/docs/federation/subgraph-spec/).
+
+### Run compatibility test
+Execute the following command from the repo root
+```
+npx @apollo/federation-subgraph-compatibility docker --compose example/product/docker-compose.yaml --schema example/product/products.graphql
+```
+
+### Printing the GraphQL schema (SQL)
+
+```
+sbt "example-product/run printSchema"
+```

--- a/example/product/docker-compose.yaml
+++ b/example/product/docker-compose.yaml
@@ -1,0 +1,7 @@
+services:
+  products:
+    build:
+      context: .
+      dockerfile: ./example/product/Dockerfile
+    ports:
+      - 4001:4001

--- a/example/product/products.graphql
+++ b/example/product/products.graphql
@@ -1,0 +1,83 @@
+extend schema
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.3"
+    import: [
+      "@composeDirective"
+      "@extends"
+      "@external"
+      "@key"
+      "@inaccessible"
+      "@interfaceObject"
+      "@override"
+      "@provides"
+      "@requires"
+      "@shareable"
+      "@tag"
+    ]
+  )
+  @link(url: "https://myspecs.dev/myCustomDirective/v1.0", import: ["@custom"])
+  @composeDirective(name: "@custom")
+
+directive @custom on OBJECT
+
+type Product
+  @custom
+  @key(fields: "id")
+  @key(fields: "sku package")
+  @key(fields: "sku variation { id }") {
+  id: ID!
+  sku: String
+  package: String
+  variation: ProductVariation
+  dimensions: ProductDimension
+  createdBy: User @provides(fields: "totalProductsCreated")
+  notes: String @tag(name: "internal")
+  research: [ProductResearch!]!
+}
+
+type DeprecatedProduct @key(fields: "sku package") {
+  sku: String!
+  package: String!
+  reason: String
+  createdBy: User
+}
+
+type ProductVariation {
+  id: ID!
+}
+
+type ProductResearch @key(fields: "study { caseNumber }") {
+  study: CaseStudy!
+  outcome: String
+}
+
+type CaseStudy {
+  caseNumber: ID!
+  description: String
+}
+
+type ProductDimension @shareable {
+  size: String
+  weight: Float
+  unit: String @inaccessible
+}
+
+extend type Query {
+  product(id: ID!): Product
+  deprecatedProduct(sku: String!, package: String!): DeprecatedProduct
+    @deprecated(reason: "Use product query instead")
+}
+
+extend type User @key(fields: "email") {
+  averageProductsCreatedPerYear: Int
+    @requires(fields: "totalProductsCreated yearsOfEmployment")
+  email: ID! @external
+  name: String @override(from: "users")
+  totalProductsCreated: Int @external
+  yearsOfEmployment: Int! @external
+}
+
+type Inventory @interfaceObject @key(fields: "id") {
+  id: ID!
+  deprecatedProducts: [DeprecatedProduct!]!
+}

--- a/example/product/src/main/scala/Main.scala
+++ b/example/product/src/main/scala/Main.scala
@@ -1,0 +1,69 @@
+import cats.effect.{ExitCode, IO, IOApp}
+import com.comcast.ip4s.IpLiteralSyntax
+import graphql.{
+  AppContext,
+  CustomDirectiveSpec,
+  GraphQLSchema,
+  InventoryGraphQLSchema,
+  ProductGraphQLSchema,
+  UserGraphQLSchema
+}
+import http.{GraphQLExecutor, GraphQLServer}
+import io.circe.Json
+import sangria.federation.v2.{CustomDirectivesDefinition, Federation, Spec}
+import sangria.marshalling.InputUnmarshaller
+import sangria.renderer.QueryRenderer
+import sangria.schema.Schema
+import service.{ProductResearchService, ProductService, UserService}
+
+object Main extends IOApp {
+
+  override def run(args: List[String]): IO[ExitCode] = (args match {
+    case "printSchema" :: Nil => printSchema
+    case _ => runGraphQLServer
+  }).as(ExitCode.Success)
+
+  private def printSchema: IO[Unit] =
+    for {
+      schema <- IO(schemaAndUm).map(_._1)
+      _ <- IO.println(QueryRenderer.renderPretty(schema.toAst))
+    } yield ()
+
+  private def runGraphQLServer: IO[Unit] =
+    for {
+      ctx <- appContext
+      executor <- graphQLExecutor(ctx)
+      host = host"0.0.0.0"
+      port = port"4001"
+      _ <- IO.println(s"starting GraphQL HTTP server on http://$host:$port")
+      _ <- GraphQLServer.bind(executor, host, port).use(_ => IO.never)
+    } yield ()
+
+  private def appContext: IO[AppContext] = IO {
+    new AppContext {
+      override def productService: ProductService = ProductService.inMemory
+      override def productResearchService: ProductResearchService = ProductResearchService.inMemory
+      override def userService: UserService = UserService.inMemory
+    }
+  }
+
+  private def schemaAndUm: (Schema[AppContext, Unit], InputUnmarshaller[Json]) =
+    Federation.federate(
+      GraphQLSchema.schema,
+      CustomDirectivesDefinition(
+        Spec("https://myspecs.dev/myCustomDirective/v1.0") -> List(
+          CustomDirectiveSpec.CustomDirectiveDefinition)
+      ),
+      sangria.marshalling.circe.CirceInputUnmarshaller,
+      ProductGraphQLSchema.productResolver,
+      ProductGraphQLSchema.deprecatedProductResolver,
+      ProductGraphQLSchema.productResearchResolver,
+      UserGraphQLSchema.userResolver,
+      InventoryGraphQLSchema.inventoryResolver
+    )
+
+  private def graphQLExecutor(context: AppContext): IO[GraphQLExecutor[AppContext]] = IO {
+    val (schema, um) = schemaAndUm
+    GraphQLExecutor(schema, context)(um)
+  }
+}

--- a/example/product/src/main/scala/graphql/AppContext.scala
+++ b/example/product/src/main/scala/graphql/AppContext.scala
@@ -1,0 +1,9 @@
+package graphql
+
+import service.{ProductResearchService, ProductService, UserService}
+
+trait AppContext {
+  def productService: ProductService
+  def productResearchService: ProductResearchService
+  def userService: UserService
+}

--- a/example/product/src/main/scala/graphql/CustomDirectiveSpec.scala
+++ b/example/product/src/main/scala/graphql/CustomDirectiveSpec.scala
@@ -1,0 +1,10 @@
+package graphql
+
+import sangria.ast
+import sangria.schema
+
+object CustomDirectiveSpec {
+  val CustomDirective: ast.Directive = ast.Directive("custom")
+  val CustomDirectiveDefinition: schema.Directive =
+    schema.Directive("custom", locations = Set(schema.DirectiveLocation.Object))
+}

--- a/example/product/src/main/scala/graphql/GraphQLSchema.scala
+++ b/example/product/src/main/scala/graphql/GraphQLSchema.scala
@@ -1,0 +1,24 @@
+package graphql
+
+import graphql.InventoryGraphQLSchema.InventoryType
+import graphql.ProductGraphQLSchema.{deprecatedProductQueryField, productQueryField}
+import graphql.UserGraphQLSchema.UserType
+import sangria.schema._
+
+object GraphQLSchema {
+  private val QueryType: ObjectType[AppContext, Unit] =
+    ObjectType(
+      name = "Query",
+      fieldsFn = () =>
+        fields[AppContext, Unit](
+          productQueryField,
+          deprecatedProductQueryField
+        )
+    )
+
+  val schema: Schema[AppContext, Unit] = Schema(
+    query = QueryType,
+    mutation = None,
+    additionalTypes = List(UserType, InventoryType)
+  )
+}

--- a/example/product/src/main/scala/graphql/InventoryGraphQLSchema.scala
+++ b/example/product/src/main/scala/graphql/InventoryGraphQLSchema.scala
@@ -1,0 +1,34 @@
+package graphql
+
+import io.circe.Json
+import model.{ID, Inventory}
+import graphql.ProductGraphQLSchema.DeprecatedProductType
+import io.circe.generic.semiauto.deriveDecoder
+import sangria.federation.v2.Directives.{InterfaceObject, Key}
+import sangria.federation.v2.{Decoder, EntityResolver}
+import sangria.schema._
+
+object InventoryGraphQLSchema {
+  val InventoryType: ObjectType[Unit, Inventory] = ObjectType(
+    "Inventory",
+    fields = fields[Unit, Inventory](
+      Field("id", IDType, resolve = _.value.id.value),
+      Field(
+        "deprecatedProducts",
+        ListType(DeprecatedProductType),
+        resolve = _.value.deprecatedProducts
+      )
+    )
+  ).withDirectives(Key("id"), InterfaceObject)
+
+  case class InventoryArgs(id: ID)
+
+  val jsonDecoder: io.circe.Decoder[InventoryArgs] = deriveDecoder[InventoryArgs]
+  val decoder: Decoder[Json, InventoryArgs] = jsonDecoder.decodeJson
+
+  def inventoryResolver: EntityResolver[AppContext, Json] { type Arg = InventoryArgs } =
+    EntityResolver[AppContext, Json, Inventory, InventoryArgs](
+      __typeName = InventoryType.name,
+      (arg, ctx) => ctx.ctx.productService.inventory(arg.id)
+    )(decoder)
+}

--- a/example/product/src/main/scala/graphql/ProductGraphQLSchema.scala
+++ b/example/product/src/main/scala/graphql/ProductGraphQLSchema.scala
@@ -1,0 +1,179 @@
+package graphql
+
+import graphql.CustomDirectiveSpec.CustomDirective
+import graphql.UserGraphQLSchema.UserType
+import io.circe.Json
+import io.circe.generic.semiauto._
+import model._
+import sangria.federation.v2.Directives._
+import sangria.federation.v2.{Decoder, EntityResolver}
+import sangria.schema._
+
+object ProductGraphQLSchema {
+  private val ProductVariationType: ObjectType[Unit, ProductVariation] = ObjectType(
+    "ProductVariation",
+    fields = fields[Unit, ProductVariation](
+      Field("id", IDType, resolve = _.value.id.value)
+    )
+  )
+
+  private val ProductDimensionType: ObjectType[Unit, ProductDimension] = ObjectType(
+    "ProductDimension",
+    fields = fields[Unit, ProductDimension](
+      Field("size", OptionType(StringType), resolve = _.value.size),
+      Field("weight", OptionType(FloatType), resolve = _.value.weight),
+      Field(
+        "unit",
+        OptionType(StringType),
+        resolve = _.value.unit,
+        astDirectives = Vector(Inaccessible))
+    )
+  ).withDirective(Shareable)
+
+  private val CaseStudyType: ObjectType[Unit, CaseStudy] = ObjectType(
+    "CaseStudy",
+    fields = fields[Unit, CaseStudy](
+      Field("caseNumber", IDType, resolve = _.value.caseNumber.value),
+      Field("description", OptionType(StringType), resolve = _.value.description)
+    )
+  )
+
+  private val ProductResearchType: ObjectType[Unit, ProductResearch] = ObjectType(
+    "ProductResearch",
+    fields = fields[Unit, ProductResearch](
+      Field("study", CaseStudyType, resolve = _.value.study),
+      Field("outcome", OptionType(StringType), resolve = _.value.outcome)
+    )
+  ).withDirective(Key("study { caseNumber }"))
+
+  private val ProductType: ObjectType[Unit, Product] = ObjectType(
+    "Product",
+    fields = fields[Unit, Product](
+      Field("id", IDType, resolve = _.value.id.value),
+      Field("sku", OptionType(StringType), resolve = _.value.sku),
+      Field("package", OptionType(StringType), resolve = _.value.`package`),
+      Field("variation", OptionType(ProductVariationType), resolve = _.value.variation),
+      Field("dimensions", OptionType(ProductDimensionType), resolve = _.value.dimensions),
+      Field(
+        "createdBy",
+        OptionType(UserType),
+        resolve = _.value.createdBy,
+        astDirectives = Vector(Provides("totalProductsCreated"))
+      ),
+      Field(
+        "notes",
+        OptionType(StringType),
+        resolve = _.value.notes,
+        astDirectives = Vector(Tag("internal"))),
+      Field("research", ListType(ProductResearchType), resolve = _.value.research)
+    )
+  ).withDirectives(
+    CustomDirective,
+    Key("id"),
+    Key("sku package"),
+    Key("sku variation { id }")
+  )
+
+  val DeprecatedProductType: ObjectType[Unit, DeprecatedProduct] = ObjectType(
+    "DeprecatedProduct",
+    fields = fields[Unit, DeprecatedProduct](
+      Field("sku", StringType, resolve = _.value.sku),
+      Field("package", StringType, resolve = _.value.`package`),
+      Field("reason", OptionType(StringType), resolve = _.value.reason),
+      Field("createdBy", OptionType(UserType), resolve = _.value.createdBy)
+    )
+  ).withDirective(Key("sku package"))
+
+  val IdArg: Argument[String] = Argument("id", IDType)
+  val SkuArg: Argument[String] = Argument("sku", StringType)
+  val PackageArg: Argument[String] = Argument("package", StringType)
+
+  val productQueryField: Field[AppContext, Unit] = Field(
+    "product",
+    OptionType(ProductType),
+    arguments = List(IdArg),
+    resolve = ctx => ctx.ctx.productService.product(ID(ctx.arg(IdArg)))
+  )
+
+  val deprecatedProductQueryField: Field[AppContext, Unit] = Field(
+    name = "deprecatedProduct",
+    fieldType = OptionType(DeprecatedProductType),
+    deprecationReason = Some("Use product query instead"),
+    arguments = List(SkuArg, PackageArg),
+    resolve = ctx => ctx.ctx.productService.deprecatedProduct(ctx.arg(SkuArg), ctx.arg(PackageArg))
+  )
+
+  case class DeprecatedProductArgs(sku: String, `package`: String)
+  object DeprecatedProductArgs {
+    val jsonDecoder: io.circe.Decoder[DeprecatedProductArgs] = deriveDecoder[DeprecatedProductArgs]
+    implicit val decoder: Decoder[Json, DeprecatedProductArgs] = jsonDecoder.decodeJson
+  }
+
+  case class CaseStudyArgs(caseNumber: ID)
+  object CaseStudyArgs {
+    implicit val jsonDecoder: io.circe.Decoder[CaseStudyArgs] = deriveDecoder[CaseStudyArgs]
+  }
+
+  case class ProductResearchArgs(study: CaseStudyArgs)
+  object ProductResearchArgs {
+    val jsonDecoder: io.circe.Decoder[ProductResearchArgs] = deriveDecoder[ProductResearchArgs]
+    implicit val decoder: Decoder[Json, ProductResearchArgs] = jsonDecoder.decodeJson
+  }
+
+  sealed trait ProductArgs
+
+  object ProductArgs {
+    import cats.syntax.functor._
+
+    case class IdOnly(id: ID) extends ProductArgs
+    object IdOnly {
+      implicit val jsonDecoder: io.circe.Decoder[IdOnly] = deriveDecoder[IdOnly]
+    }
+
+    case class SkuAndPackage(sku: String, `package`: String) extends ProductArgs
+    object SkuAndPackage {
+      implicit val jsonDecoder: io.circe.Decoder[SkuAndPackage] = deriveDecoder[SkuAndPackage]
+    }
+
+    case class SkuAndVariationId(sku: String, variation: ProductVariation) extends ProductArgs
+    object SkuAndVariationId {
+      implicit val jsonDecoder: io.circe.Decoder[SkuAndVariationId] =
+        deriveDecoder[SkuAndVariationId]
+    }
+
+    val jsonDecoder: io.circe.Decoder[ProductArgs] = List[io.circe.Decoder[ProductArgs]](
+      io.circe.Decoder[IdOnly].widen,
+      io.circe.Decoder[SkuAndPackage].widen,
+      io.circe.Decoder[SkuAndVariationId].widen
+    ).reduceLeft(_ or _)
+    implicit val decoder: Decoder[Json, ProductArgs] = jsonDecoder.decodeJson
+  }
+
+  implicit val decoder: Decoder[Json, ID] = ID.decoder.decodeJson
+
+  def productResearchResolver: EntityResolver[AppContext, Json] { type Arg = ProductResearchArgs } =
+    EntityResolver[AppContext, Json, ProductResearch, ProductResearchArgs](
+      ProductResearchType.name,
+      (arg, ctx) => ctx.ctx.productResearchService.productResearch(arg.study.caseNumber)
+    )
+
+  def productResolver: EntityResolver[AppContext, Json] { type Arg = ProductArgs } =
+    EntityResolver[AppContext, Json, Product, ProductArgs](
+      ProductType.name,
+      (arg, ctx) =>
+        arg match {
+          case ProductArgs.IdOnly(id) => ctx.ctx.productService.product(id)
+          case ProductArgs.SkuAndPackage(sku, pack) =>
+            ctx.ctx.productService.bySkuAndPackage(sku, pack)
+          case ProductArgs.SkuAndVariationId(sku, variation) =>
+            ctx.ctx.productService.bySkuAndProductVariantionId(sku, variation)
+        }
+    )
+
+  def deprecatedProductResolver
+      : EntityResolver[AppContext, Json] { type Arg = DeprecatedProductArgs } =
+    EntityResolver[AppContext, Json, DeprecatedProduct, DeprecatedProductArgs](
+      DeprecatedProductType.name,
+      (arg, ctx) => ctx.ctx.productService.deprecatedProduct(arg.sku, arg.`package`)
+    )
+}

--- a/example/product/src/main/scala/graphql/UserGraphQLSchema.scala
+++ b/example/product/src/main/scala/graphql/UserGraphQLSchema.scala
@@ -1,0 +1,55 @@
+package graphql
+
+import io.circe.Json
+import model.{ID, User}
+import sangria.federation.v2.Directives._
+import sangria.federation.v2.{Decoder, EntityResolver}
+import sangria.schema._
+
+object UserGraphQLSchema {
+  // should be "extend", but according to the spec, an extend type can only exist if there is one type:
+  // http://spec.graphql.org/draft/#sec-Object-Extensions.Type-Validation
+  val UserType: ObjectType[Unit, User] = ObjectType(
+    "User",
+    fields = fields[Unit, User](
+      Field("email", IDType, resolve = _.value.email.value, astDirectives = Vector(External)),
+      Field(
+        "name",
+        OptionType(StringType),
+        resolve = _.value.name,
+        astDirectives = Vector(Override("users"))),
+      Field(
+        "yearsOfEmployment",
+        IntType,
+        resolve = _.value.yearsOfEmployment,
+        astDirectives = Vector(External)),
+      Field(
+        "totalProductsCreated",
+        OptionType(IntType),
+        resolve = _.value.totalProductsCreated,
+        astDirectives = Vector(External)
+      ),
+      Field(
+        "averageProductsCreatedPerYear",
+        OptionType(IntType),
+        resolve = _.value.averageProductsCreatedPerYear,
+        astDirectives = Vector(Requires("totalProductsCreated yearsOfEmployment"))
+      )
+    )
+  ).withDirective(Key("email"))
+
+  implicit val decoder: Decoder[Json, ID] = ID.decoder.decodeJson
+
+  case class UserArgs(email: ID)
+  object UserArgs {
+    import io.circe.generic.semiauto._
+    val jsonDecoder: io.circe.Decoder[UserArgs] = deriveDecoder[UserArgs]
+    implicit val decoder: Decoder[Json, UserArgs] = jsonDecoder.decodeJson
+  }
+
+  def userResolver: EntityResolver[AppContext, Json] { type Arg = UserArgs } =
+    EntityResolver[AppContext, Json, User, UserArgs](
+      __typeName = UserType.name,
+      (arg, ctx) => ctx.ctx.userService.user(arg.email)
+    )
+}

--- a/example/product/src/main/scala/http/GraphQLError.scala
+++ b/example/product/src/main/scala/http/GraphQLError.scala
@@ -1,0 +1,41 @@
+package http
+
+import io.circe.Json
+import sangria.execution.WithViolations
+import sangria.parser.SyntaxError
+import sangria.validation.AstNodeViolation
+
+object GraphQLError {
+  def apply(s: String): Json = Json.obj(
+    "errors" -> Json.arr(
+      Json.obj("message" -> Json.fromString(s))
+    )
+  )
+
+  def apply(e: SyntaxError): Json = Json.obj(
+    "errors" -> Json.arr(
+      Json.obj(
+        "message" -> Json.fromString(e.getMessage),
+        "locations" -> Json.arr(
+          Json.obj(
+            "line" -> Json.fromInt(e.originalError.position.line),
+            "column" -> Json.fromInt(e.originalError.position.column)
+          )
+        )
+      )
+    )
+  )
+
+  def apply(e: WithViolations): Json =
+    Json.obj("errors" -> Json.fromValues(e.violations.map {
+      case v: AstNodeViolation =>
+        Json.obj(
+          "message" -> Json.fromString(v.errorMessage),
+          "locations" -> Json.fromValues(
+            v.locations.map(loc =>
+              Json.obj("line" -> Json.fromInt(loc.line), "column" -> Json.fromInt(loc.column)))
+          )
+        )
+      case v => Json.obj("message" -> Json.fromString(v.errorMessage))
+    }))
+}

--- a/example/product/src/main/scala/http/GraphQLExecutor.scala
+++ b/example/product/src/main/scala/http/GraphQLExecutor.scala
@@ -1,0 +1,68 @@
+package http
+
+import io.circe.optics.JsonPath.root
+import io.circe.{Json, JsonObject}
+import sangria.ast
+import sangria.execution.{Executor, Middleware}
+import sangria.marshalling.InputUnmarshaller
+import sangria.marshalling.circe.CirceResultMarshaller
+import sangria.parser.{QueryParser, SyntaxError}
+import sangria.schema.Schema
+
+import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+trait GraphQLExecutor[Ctx] {
+  def query(request: Json, middleware: List[Middleware[Ctx]]): Future[Json]
+}
+
+object GraphQLExecutor {
+  private val queryStringLens = root.query.string
+  private val operationNameLens = root.operationName.string
+  private val variablesLens = root.variables.obj
+
+  def apply[Ctx](schema: Schema[Ctx, Unit], context: Ctx)(implicit
+      um: InputUnmarshaller[Json]): GraphQLExecutor[Ctx] =
+    new GraphQLExecutor[Ctx] {
+      override def query(request: Json, middleware: List[Middleware[Ctx]]): Future[Json] = {
+        val queryString = queryStringLens.getOption(request)
+        val operationName = operationNameLens.getOption(request)
+        val variables =
+          Json.fromJsonObject(variablesLens.getOption(request).getOrElse(JsonObject.empty))
+
+        queryString match {
+          case Some(qs) => query(qs, operationName, variables, middleware)
+          case None =>
+            Future.successful(GraphQLError("No 'query' property was present in the request."))
+        }
+      }
+
+      private def query(
+          query: String,
+          operationName: Option[String],
+          variables: Json,
+          middleware: List[Middleware[Ctx]]
+      ): Future[Json] =
+        QueryParser.parse(query) match {
+          case Success(ast) => exec(ast, operationName, variables, middleware)
+          case Failure(e: SyntaxError) => Future.successful(http.GraphQLError(e))
+          case Failure(e) => Future.failed(e)
+        }
+
+      private def exec(
+          query: ast.Document,
+          operationName: Option[String],
+          variables: Json,
+          middleware: List[Middleware[Ctx]]
+      ): Future[Json] =
+        Executor.execute(
+          schema = schema,
+          queryAst = query,
+          userContext = context,
+          variables = variables,
+          operationName = operationName,
+          middleware = middleware
+        )
+    }
+}

--- a/example/product/src/main/scala/http/GraphQLServer.scala
+++ b/example/product/src/main/scala/http/GraphQLServer.scala
@@ -1,0 +1,51 @@
+package http
+
+import cats.data.NonEmptyList
+import cats.effect.{IO, ResourceIO}
+import com.comcast.ip4s.{Host, Port}
+import io.circe.Json
+import org.http4s.circe._
+import org.http4s.dsl.Http4sDsl
+import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.server.Server
+import org.http4s.{Header, HttpRoutes}
+import org.typelevel.ci.CIString
+import sangria.execution.Middleware
+import sangria.federation.tracing.ApolloFederationTracing
+
+object GraphQLServer {
+
+  private object `apollo-federation-include-trace` {
+    val name: CIString = CIString("apollo-federation-include-trace")
+    val header: Header.Raw = Header.Raw(name, "ftv1")
+    val oneHeader: NonEmptyList[Header.Raw] = NonEmptyList.one(header)
+  }
+
+  def routes[Ctx](executor: GraphQLExecutor[Ctx]): HttpRoutes[IO] = {
+    val dsl = new Http4sDsl[IO] {}
+    import dsl._
+    HttpRoutes.of[IO] { case req @ POST -> Root =>
+      val tracing = req.headers
+        .get(`apollo-federation-include-trace`.name)
+        .contains(`apollo-federation-include-trace`.oneHeader)
+
+      val middleware: List[Middleware[Ctx]] = if (tracing) ApolloFederationTracing :: Nil else Nil
+      for {
+        json <- req.as[Json]
+        result <- IO.fromFuture(IO.delay(executor.query(json, middleware)))
+        httpResult <- Ok(result)
+      } yield httpResult
+    }
+  }
+
+  def bind[Ctx](executor: GraphQLExecutor[Ctx], host: Host, port: Port): ResourceIO[Server] = {
+    val httpApp = routes(executor).orNotFound
+
+    EmberServerBuilder
+      .default[IO]
+      .withHost(host)
+      .withPort(port)
+      .withHttpApp(httpApp)
+      .build
+  }
+}

--- a/example/product/src/main/scala/model/ID.scala
+++ b/example/product/src/main/scala/model/ID.scala
@@ -1,0 +1,9 @@
+package model
+
+import io.circe.Decoder
+
+case class ID(value: String) extends AnyVal
+
+object ID {
+  implicit val decoder: Decoder[ID] = Decoder.decodeString.map(ID.apply)
+}

--- a/example/product/src/main/scala/model/Inventory.scala
+++ b/example/product/src/main/scala/model/Inventory.scala
@@ -1,0 +1,3 @@
+package model
+
+case class Inventory(id: ID, deprecatedProducts: List[DeprecatedProduct])

--- a/example/product/src/main/scala/model/Product.scala
+++ b/example/product/src/main/scala/model/Product.scala
@@ -1,0 +1,39 @@
+package model
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+case class ProductVariation(id: ID)
+object ProductVariation {
+  implicit val jsonDecoder: Decoder[ProductVariation] = deriveDecoder[ProductVariation]
+}
+
+case class ProductDimension(size: Option[String], weight: Option[Double], unit: Option[String])
+
+case class CaseStudy(
+    caseNumber: ID,
+    description: Option[String]
+)
+
+case class ProductResearch(
+    study: CaseStudy,
+    outcome: Option[String] = None
+)
+
+case class Product(
+    id: ID,
+    sku: Option[String],
+    `package`: Option[String],
+    variation: Option[ProductVariation],
+    dimensions: Option[ProductDimension],
+    createdBy: Option[User],
+    research: List[ProductResearch],
+    notes: Option[String] = None
+)
+
+case class DeprecatedProduct(
+    sku: String,
+    `package`: String,
+    reason: Option[String],
+    createdBy: Option[User]
+)

--- a/example/product/src/main/scala/model/User.scala
+++ b/example/product/src/main/scala/model/User.scala
@@ -1,0 +1,11 @@
+package model
+
+case class User(
+    email: ID,
+    name: Option[String],
+    totalProductsCreated: Option[Int],
+    yearsOfEmployment: Int
+) {
+  def averageProductsCreatedPerYear: Option[Int] =
+    totalProductsCreated.map(_ / yearsOfEmployment)
+}

--- a/example/product/src/main/scala/service/ProductResearchService.scala
+++ b/example/product/src/main/scala/service/ProductResearchService.scala
@@ -1,0 +1,18 @@
+package service
+
+import model._
+
+import scala.concurrent.Future
+
+trait ProductResearchService {
+  def productResearch(studyCaseNumber: ID): Future[Option[ProductResearch]]
+}
+
+object ProductResearchService {
+  private val productResearch1 = ProductResearch(CaseStudy(ID("1234"), Some("Federation Study")))
+  private val productResearch2 = ProductResearch(CaseStudy(ID("1235"), Some("Studio Study")))
+  private val productResearches: List[ProductResearch] = List(productResearch1, productResearch2)
+
+  val inMemory: ProductResearchService = (studyCaseNumber: ID) =>
+    Future.successful(productResearches.find(_.study.caseNumber == studyCaseNumber))
+}

--- a/example/product/src/main/scala/service/ProductService.scala
+++ b/example/product/src/main/scala/service/ProductService.scala
@@ -1,0 +1,81 @@
+package service
+
+import model._
+import service.UserService.user
+
+import scala.concurrent.Future
+
+trait ProductService {
+  def product(id: ID): Future[Option[Product]]
+  def bySkuAndPackage(sku: String, `package`: String): Future[Option[Product]]
+  def bySkuAndProductVariantionId(sku: String, variation: ProductVariation): Future[Option[Product]]
+  def deprecatedProduct(sku: String, `package`: String): Future[Option[DeprecatedProduct]]
+  def inventory(id: ID): Future[Option[Inventory]]
+}
+
+object ProductService {
+  private val dimension = ProductDimension(Some("small"), Some(1.0f), Some("kg"))
+
+  private val deprecatedProduct = DeprecatedProduct(
+    sku = "apollo-federation-v1",
+    `package` = "@apollo/federation-v1",
+    reason = Some("Migrate to Federation V2"),
+    createdBy = Some(user)
+  )
+
+  private val product1 = Product(
+    id = ID("apollo-federation"),
+    sku = Some("federation"),
+    `package` = Some("@apollo/federation"),
+    variation = Some(ProductVariation(ID("OSS"))),
+    dimensions = Some(dimension),
+    research = List(ProductResearch(CaseStudy(ID("1234"), Some("Federation Study")))),
+    createdBy = Some(user)
+  )
+
+  private val product2 = Product(
+    id = ID("apollo-studio"),
+    sku = Some("studio"),
+    `package` = Some(""),
+    variation = Some(ProductVariation(ID("platform"))),
+    dimensions = Some(dimension),
+    research = List(ProductResearch(CaseStudy(ID("1235"), Some("Studio Study")))),
+    createdBy = Some(user)
+  )
+
+  private val products: List[Product] = List(product1, product2)
+  private val deprecatedProducts: List[DeprecatedProduct] = List(deprecatedProduct)
+
+  private val inventoryList: List[Inventory] = List(
+    Inventory(
+      id = ID("apollo-oss"),
+      deprecatedProducts = deprecatedProducts
+    )
+  )
+
+  val inMemory: ProductService = new ProductService {
+    override def product(id: ID): Future[Option[Product]] =
+      Future.successful(products.find(_.id == id))
+
+    override def bySkuAndPackage(sku: String, `package`: String): Future[Option[Product]] =
+      Future.successful(products.find { p =>
+        p.sku.contains(sku) && p.`package`.contains(`package`)
+      })
+
+    override def bySkuAndProductVariantionId(
+        sku: String,
+        variation: ProductVariation): Future[Option[Product]] =
+      Future.successful(products.find { p =>
+        p.sku.contains(sku) &&
+        p.variation.exists(_.id == variation.id)
+      })
+
+    override def deprecatedProduct(
+        sku: String,
+        `package`: String): Future[Option[DeprecatedProduct]] =
+      Future.successful(deprecatedProducts.find(p => p.sku == sku && p.`package` == `package`))
+
+    def inventory(id: ID): Future[Option[Inventory]] =
+      Future.successful(inventoryList.find(_.id == id))
+  }
+}

--- a/example/product/src/main/scala/service/UserService.scala
+++ b/example/product/src/main/scala/service/UserService.scala
@@ -1,0 +1,22 @@
+package service
+
+import model.{ID, User}
+
+import scala.concurrent.Future
+
+trait UserService {
+  def user(email: ID): Future[Option[User]]
+}
+
+object UserService {
+  val user: User = User(
+    email = ID("support@apollographql.com"),
+    name = Some("Jane Smith"),
+    totalProductsCreated = Some(1337),
+    yearsOfEmployment = 10
+  )
+
+  private val users = List(user)
+
+  val inMemory: UserService = (email: ID) => Future.successful(users.find(_.email == email))
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,7 @@ object Dependencies {
   val http4sCirce = "org.http4s" %% "http4s-circe" % V.http4s
   val http4sDsl = "org.http4s" %% "http4s-dsl" % V.http4s
 
+  val circeCore = "io.circe" %% "circe-core" % V.circe
   val circeGeneric = "io.circe" %% "circe-generic" % V.circe
   val circeParser = "io.circe" %% "circe-parser" % V.circe
   val circeOptics = "io.circe" %% "circe-optics" % V.circeOptics


### PR DESCRIPTION
Adds a copy of the product subgraph implemented in [apollo-federation-subgraph-compatibility](https://github.com/apollographql/apollo-federation-subgraph-compatibility/tree/main/implementations/sangria) repo.

Also includes a Github action to run on each pull request which checks compatibility against [Apollo Federation Subgraph Specification](https://www.apollographql.com/docs/federation/subgraph-spec/) and posts the results to the PR.

Targets #215 