### PR TITLE
use minimal federation version

### DIFF
--- a/core/src/main/scala/sangria/federation/v2/Federation.scala
+++ b/core/src/main/scala/sangria/federation/v2/Federation.scala
@@ -111,8 +111,11 @@ object Federation {
       else
         federationDirectives
 
+    val minorVersion: Int =
+      (0 :: importedDirectives.map(d => minorVersionOf.getOrElse(d.name, 0))).max
+
     val federationV2Link = Directives.Link(
-      url = "https://specs.apollo.dev/federation/v2.9",
+      url = s"https://specs.apollo.dev/federation/v2.$minorVersion",
       `import` = Some(importedDirectives.map(d => Link__Import("@" + d.name)).toVector)
     )
 
@@ -176,6 +179,21 @@ object Federation {
         )
     }).copy(directives = Directives.Link.definition :: extendedSchema.directives)
   }
+
+  /** Minor version of the [[https://specs.apollo.dev/federation/ federation spec]] that first
+    * introduced each directive. Directives not listed here are available since `v2.0`.
+    */
+  private val minorVersionOf: Map[String, Int] = Map(
+    (Directives.ComposeDirective.definition: Directive).name -> 1,
+    Directives.InterfaceObjectDefinition.name -> 3,
+    Directives.AuthenticatedDefinition.name -> 5,
+    Directives.RequiresScopes.definition.name -> 5,
+    Directives.Policy.definition.name -> 6,
+    Directives.Context.definition.name -> 8,
+    Directives.FromContext.definition.name -> 8,
+    Directives.Cost.definition.name -> 9,
+    Directives.ListSize.definition.name -> 9
+  )
 
   /** Collects the names of all directives applied anywhere in the given schema (on types, fields,
     * arguments, enum values and input fields), so that only the federation directives that are

--- a/core/src/test/scala/sangria/federation/package.scala
+++ b/core/src/test/scala/sangria/federation/package.scala
@@ -8,7 +8,7 @@ import sangria.schema.SchemaChange.AbstractChange
 
 package object federation {
 
-  val spec: String = "https://specs.apollo.dev/federation/v2.9"
+  val spec: String = "https://specs.apollo.dev/federation/v2.1"
 
   def beCompatibleWith(expectedSchema: Schema[_, _]): Matcher[Schema[_, _]] =
     Matcher { (schema: Schema[_, _]) =>

--- a/core/src/test/scala/sangria/federation/v2/FederationSpec.scala
+++ b/core/src/test/scala/sangria/federation/v2/FederationSpec.scala
@@ -37,7 +37,7 @@ class FederationSpec extends AsyncFreeSpec {
 
         val expectedSubGraphSchema = Schema
           .buildFromAst(graphql"""
-            schema @link(url: "https://specs.apollo.dev/federation/v2.9", import: []) {
+            schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: []) {
               query: Query
             }
 
@@ -99,7 +99,7 @@ class FederationSpec extends AsyncFreeSpec {
 
         val expectedSubGraphSchema = Schema
           .buildFromAst(graphql"""
-            schema @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@key"]) {
+            schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"]) {
               query: Query
             }
 
@@ -171,7 +171,7 @@ class FederationSpec extends AsyncFreeSpec {
         val schema = Federation.extend(sangria.schema.Schema(QueryType), Nil)
 
         SchemaRenderer.renderSchema(schema) should include(
-          """@link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@shareable", "@tag"])""")
+          """@link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@shareable", "@tag"])""")
       }
 
       "only imports the federation__Scope scalar when @requiresScopes is used" in {
@@ -192,7 +192,7 @@ class FederationSpec extends AsyncFreeSpec {
           SchemaRenderer.renderSchema(Federation.extend(sangria.schema.Schema(QueryType), Nil))
 
         rendered should include(
-          """@link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@requiresScopes"])""")
+          """@link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@requiresScopes"])""")
         rendered should include("scalar federation__Scope")
         (rendered should not).include("scalar federation__Policy")
         (rendered should not).include("scalar federation__ContextFieldValue")
@@ -216,7 +216,7 @@ class FederationSpec extends AsyncFreeSpec {
           SchemaRenderer.renderSchema(Federation.extend(sangria.schema.Schema(QueryType), Nil))
 
         rendered should include(
-          """@link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@policy"])""")
+          """@link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@policy"])""")
         rendered should include("scalar federation__Policy")
         (rendered should not).include("scalar federation__Scope")
         (rendered should not).include("scalar federation__ContextFieldValue")
@@ -240,7 +240,7 @@ class FederationSpec extends AsyncFreeSpec {
           SchemaRenderer.renderSchema(Federation.extend(sangria.schema.Schema(QueryType), Nil))
 
         rendered should include(
-          """@link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@fromContext"])""")
+          """@link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@fromContext"])""")
         rendered should include("scalar federation__ContextFieldValue")
         (rendered should not).include("scalar federation__Scope")
         (rendered should not).include("scalar federation__Policy")
@@ -278,7 +278,7 @@ class FederationSpec extends AsyncFreeSpec {
             .map(QueryRenderer.renderPretty(_) should be("""{
                 |  data: {
                 |    _service: {
-                |      sdl: "schema @link(url: \"https://specs.apollo.dev/federation/v2.9\", import: []) {\n  query: Query\n}\n\ntype Query {\n  field: Int\n}"
+                |      sdl: "schema @link(url: \"https://specs.apollo.dev/federation/v2.0\", import: []) {\n  query: Query\n}\n\ntype Query {\n  field: Int\n}"
                 |    }
                 |  }
                 |}""".stripMargin))
@@ -308,7 +308,7 @@ class FederationSpec extends AsyncFreeSpec {
             .map(QueryRenderer.renderPretty(_) should be("""{
                 |  data: {
                 |    _service: {
-                |      sdl: "schema @link(url: \"https://specs.apollo.dev/federation/v2.9\", import: [\"@key\"]) {\n  query: Query\n}\n\ntype Query {\n  states: [State]\n}\n\ntype State @key(fields: \"id\") {\n  id: Int\n  value: String\n}"
+                |      sdl: "schema @link(url: \"https://specs.apollo.dev/federation/v2.0\", import: [\"@key\"]) {\n  query: Query\n}\n\ntype Query {\n  states: [State]\n}\n\ntype State @key(fields: \"id\") {\n  id: Int\n  value: String\n}"
                 |    }
                 |  }
                 |}""".stripMargin))
@@ -335,7 +335,7 @@ class FederationSpec extends AsyncFreeSpec {
           .map(QueryRenderer.renderPretty(_) should be("""{
                 |  data: {
                 |    _service: {
-                |      sdl: "schema @link(url: \"https://specs.apollo.dev/federation/v2.9\", import: []) {\n  query: Query\n}\n\n\"The `Long` scalar type represents non-fractional signed whole numeric values. Long can represent values between -(2^63) and 2^63 - 1.\"\nscalar Long\n\ntype Query {\n  foo: Long\n  bar: Int\n}"
+                |      sdl: "schema @link(url: \"https://specs.apollo.dev/federation/v2.0\", import: []) {\n  query: Query\n}\n\n\"The `Long` scalar type represents non-fractional signed whole numeric values. Long can represent values between -(2^63) and 2^63 - 1.\"\nscalar Long\n\ntype Query {\n  foo: Long\n  bar: Int\n}"
                 |    }
                 |  }
                 |}""".stripMargin))


### PR DESCRIPTION
Insead of using the latest version, use the minimal version required by all used directives.
This allow using the minimal set supported by the rest of the federation ecosystem.